### PR TITLE
Add a basic setup script for development and update the README with instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This process is clunky right now, so my apologies.
 
 1. Clone the repo: `git clone https://github.com/GUI/covid-vaccine-spotter.git`
 2. Install dependencies (inside the repo): `yarn install`
-3. Fetch data from the [API](https://www.vaccinespotter.org/api/) for the website to run: `npm run dev`
-NOTE: the script that fetches data from the API uses only a few files to get things running, but it's not an entire dataset. You can download other states data using the format provided in `scripts/setupDev.sh`
-4. To run the development server for the website: `npm run serve`. The development site should then be available at http://localhost:8080/.
+3. Fetch data from the [API](https://www.vaccinespotter.org/api/) for the website to run: `yarn run dev`
+NOTE: the script that fetches data from the API uses only a few files to get things running, it's not an entire dataset. You can download other states data using the format provided in `scripts/setupDev.sh`
+4. To run the development server for the website: `yarn run serve`. The development site should then be available at http://localhost:8080/.
 
 TODO: While this should cover running the website with existing, this doesn't cover running the database and other pieces necessary for working on the scanners or other backend pieces. Still need to document that part.
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,9 @@ This process is clunky right now, so my apologies.
 
 1. Clone the repo: `git clone https://github.com/GUI/covid-vaccine-spotter.git`
 2. Install dependencies (inside the repo): `yarn install`
-3. Download data from the [API](https://www.vaccinespotter.org/api/) for the website to run. Note these example steps just download a few files to get things running, but it's not an entire dataset. You can download other states data, but I know this is currently a bit cumbersome.
-   - `mkdir -p site/api/v0/stores/CO`
-   - `curl -o site/api/v0/states.json https://www.vaccinespotter.org/api/v0/states.json`
-   - `curl -o site/api/v0/stores/CO/cvs.json https://www.vaccinespotter.org/api/v0/stores/CO/cvs.json`
-   - `curl -o site/api/v0/stores/CO/walgreens.json https://www.vaccinespotter.org/api/v0/stores/CO/walgreens.json`
-   - `curl -o site/api/v0/stores/CO/walmart.json https://www.vaccinespotter.org/api/v0/stores/CO/walmart.json`
-4. To run the development server for the website: `yarn run eleventy --serve`. The development site should then be available at http://localhost:8080/.
+3. Fetch data from the [API](https://www.vaccinespotter.org/api/) for the website to run: `npm run dev`
+NOTE: the script that fetches data from the API uses only a few files to get things running, but it's not an entire dataset. You can download other states data using the format provided in `scripts/setupDev.sh`
+4. To run the development server for the website: `npm run serve`. The development site should then be available at http://localhost:8080/.
 
 TODO: While this should cover running the website with existing, this doesn't cover running the database and other pieces necessary for working on the scanners or other backend pieces. Still need to document that part.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "scripts": {
     "start": "func host start --verbose",
-    "lint": "eslint 'src/**/*.js' 'migrations/**/*.js' '*.js'"
+    "lint": "eslint 'src/**/*.js' 'migrations/**/*.js' '*.js'",
+    "dev": "./scripts/setupDev.sh",
+    "serve": "yarn run eleventy --serve"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.11.1",

--- a/scripts/setupDev.sh
+++ b/scripts/setupDev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p site/api/v0/stores/CO
+curl -o site/api/v0/states.json https://www.vaccinespotter.org/api/v0/states.json
+curl -o site/api/v0/stores/CO/cvs.json https://www.vaccinespotter.org/api/v0/stores/CO/cvs.json
+curl -o site/api/v0/stores/CO/walgreens.json https://www.vaccinespotter.org/api/v0/stores/CO/walgreens.json
+curl -o site/api/v0/stores/CO/walmart.json https://www.vaccinespotter.org/api/v0/stores/CO/walmart.json


### PR DESCRIPTION
Put the existing manual dev setup commands in a script for more flexible setup.

The example dev data is now fetched with `yarn run dev` (open to suggestions on all names, btw) and the UI can be started with `yarn run serve`.

Next steps:
- Might be better to move the setup script to a JS script?
- Extend the postal code script so that multiple states can be fetched by the dev script programatically