### PR TITLE
Avoid displaying null for unknown store address or zip code

### DIFF
--- a/website/components/LocationMapPopup.vue
+++ b/website/components/LocationMapPopup.vue
@@ -2,9 +2,13 @@
   <div>
     <h6>{{ store.properties.provider_brand_name }}</h6>
     <p>
-      {{ store.properties.address }}<br />
+      <template v-if="store.properties.address">
+        {{ store.properties.address }}<br />
+      </template>
       {{ store.properties.city }}, {{ store.properties.state }}
-      {{ store.properties.postal_code }}
+      <template v-if="store.properties.postal_code">
+        {{ store.properties.postal_code }}
+      </template>
     </p>
     <div>
       <div v-if="store.properties.appointments_available === true">


### PR DESCRIPTION
The app currently displays 'null' when it doesn't know a location's exact address or zip code, so this renders those fields conditionally.

![image](https://user-images.githubusercontent.com/7783288/110729423-b1315f80-81ec-11eb-99fc-34f7e58166c4.png)
