### PR TITLE
Add Publix refresh handler (and bin)

### DIFF
--- a/bin/refresh-publix
+++ b/bin/refresh-publix
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+const { refreshCvs } = require("../src/handlers/refreshPublix");
+const runTask = require("../src/runTask");
+
+runTask(refreshPublix, 40000);

--- a/src/handlers/refreshPublix.js
+++ b/src/handlers/refreshPublix.js
@@ -1,0 +1,89 @@
+const { default: PQueue } = require("p-queue");
+const got = require("got");
+const { capitalCase } = require("capital-case");
+const logger = require("../logger");
+const { Store } = require("../models/Store");
+
+const HEADERS = {
+  "User-Agent": "covid-vaccine-finder (https://github.com/GUI/covid-vaccine-finder)"
+};
+
+function appointmentAvailabilityFromStatusString(s) {
+  if (s.startsWith('Fully Booked')) {
+    return false;
+  } else if (s.startsWith('None Available')) {
+    return false
+  } else if (s.startsWith('Less than 1%')) {
+    return true;
+  } else if (s.match(/^\d+\%/)) {
+    return true;
+  } else {
+    logger.warn(`Unrecognized availability string from Publix: ${s}`);
+    return false;
+  }
+}
+
+function patchFromLine(l, state, lastFetched) {
+  var pieces = l.split('|');
+  var county = pieces[0];
+  var status = pieces[1];
+
+  return {
+    brand: "publix",
+    brand_id: `${state}-${county}`,
+    name: `${county}, ${capitalCase(state)}`,
+    county_name: county,
+    state: state,
+    carries_vaccine: true,
+    appointments: [],
+    appointments_last_fetched: lastFetched,
+    appointments_available: appointmentAvailabilityFromStatusString(status),
+    appointments_raw: status,
+  };
+}
+
+const Publix = {
+  refreshStores: async () => {
+    logger.notice("Begin refreshing appointments for all stores...");
+
+    const queue = new PQueue({ concurrency: 5 });
+    const lastFetched = new Date().toISOString();
+    const states = [
+      'florida',
+      'georgia',
+      'south-carolina'
+    ];
+
+    states.forEach((state) => {
+      queue.add(() => {
+        return got(
+          `https://www.publix.com/covid-vaccine/${state}/${state}-county-status.txt`,
+          {
+            headers: HEADERS,
+            encoding: 'utf16le',
+            timeout: 30000,
+            retry: 0,
+          }
+        )
+        .then((res) => {
+          var lines = res.body.split(/\r?\n/);
+          lines.forEach((l) => {
+            if (!l) return; // skip blank lines (e.g. at end)
+            var patch = patchFromLine(l, state, lastFetched);
+            queue.add(() =>
+              Store.query().insert(patch).onConflict(["brand", "brand_id"]).merge()
+            );
+          });
+        })
+      });
+    });
+
+    await queue.onIdle();
+
+    logger.notice("Finished refreshing appointments for all stores.");
+  },
+};
+
+module.exports.refreshPublix = async () => {
+  await Publix.refreshStores();
+};


### PR DESCRIPTION
Hello from Publix country!

https://github.com/GUI/covid-vaccine-spotter/issues/31

What else is needed to complete Publix pharmacy working here? 

I can't confirm it's working, mostly because I can't get my database set up. Migrations fail because I don't have the postgis extension. On MacOS, I'm running postgres 12 for work. Since the latest is 13, `brew install postgis` succeeds, but installs the version of postgis for pg 13, which doesn't work with pg 12.