### PR TITLE
Tweak marker shape to make colour-blind friendly

### DIFF
--- a/website/components/LocationMap.vue
+++ b/website/components/LocationMap.vue
@@ -215,6 +215,7 @@ export default {
 
 #legend span.unavailable-marker {
   background-color: #e34a33;
+  width: 7px;
 }
 
 #legend span.unknown-marker {


### PR DESCRIPTION
Should make the 'unavailable' marker look like a minus sign.