### PR TITLE
Adjust map markers to better deal with color-blindness

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,4 @@
-const buildModules = ["@nuxtjs/google-analytics"];
+const buildModules = ["@nuxtjs/google-analytics", "@nuxtjs/svg"];
 if (process.env.NODE_ENV !== "production") {
   // https://go.nuxtjs.dev/eslint
   buildModules.push("@nuxtjs/eslint-module");

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@fortawesome/vue-fontawesome": "^2.0.2",
     "@nuxt/http": "^0.6.4",
     "@nuxtjs/google-analytics": "^2.4.0",
+    "@nuxtjs/svg": "^0.1.12",
     "@turf/bbox": "^6.3.0",
     "@turf/circle": "^6.3.0",
     "@turf/helpers": "^6.3.0",

--- a/website/assets/map-icon-circle.svg
+++ b/website/assets/map-icon-circle.svg
@@ -1,0 +1,3 @@
+<svg class="bi bi-circle-fill" width="16" height="16" fill="currentColor" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <ellipse cx="8" cy="8" rx="7.3143" ry="7.3143" fill="#006a00" stroke="#fff" stroke-width="1.3714"/>
+</svg>

--- a/website/assets/map-icon-diamond.svg
+++ b/website/assets/map-icon-diamond.svg
@@ -1,0 +1,3 @@
+<svg class="bi bi-diamond-fill" width="16" height="16" fill="currentColor" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m7.0396 1.0797c0.53058-0.53058 1.3905-0.53058 1.9211 0l5.9599 5.9607c0.53058 0.53058 0.53058 1.3896 0 1.9192l-5.9599 5.9607c-0.53058 0.53058-1.3896 0.53058-1.9192 0l-5.9617-5.9598a1.3557 1.3557 0 0 1 0-1.9192z" fill="#ea4055" fill-rule="evenodd" stroke="#fff" stroke-width="1.3722"/>
+</svg>

--- a/website/assets/map-icon-square.svg
+++ b/website/assets/map-icon-square.svg
@@ -1,0 +1,3 @@
+<svg class="bi bi-square-fill" width="16" height="16" fill="currentColor" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m0.68572 2.5143a1.8286 1.8286 0 0 1 1.8286-1.8286h10.971a1.8286 1.8286 0 0 1 1.8286 1.8286v10.971a1.8286 1.8286 0 0 1-1.8286 1.8286h-10.971a1.8286 1.8286 0 0 1-1.8286-1.8286z" fill="#aaa" stroke="#fff" stroke-width="1.3714"/>
+</svg>

--- a/website/components/LocationMap.vue
+++ b/website/components/LocationMap.vue
@@ -3,12 +3,17 @@
     <div id="map" style="width: 100%"></div>
     <div id="legend" class="map-overlay">
       <div>
-        <span class="available-marker"></span> Appointments recently available
+        <img src="~/assets/map-icon-circle.svg?data" alt="" /> Appointments
+        recently available
       </div>
       <div>
-        <span class="unavailable-marker"></span> Appointments not available
+        <img src="~/assets/map-icon-diamond.svg?data" alt="" /> Appointments not
+        available
       </div>
-      <div><span class="unknown-marker"></span> Appointment status unknown</div>
+      <div>
+        <img src="~/assets/map-icon-square.svg?data" alt="" /> Appointment
+        status unknown
+      </div>
     </div>
   </div>
 </template>
@@ -17,6 +22,9 @@
 import { Map, Marker, Popup } from "maplibre-gl";
 import Vue from "vue";
 import LocationMapPopup from "./LocationMapPopup.vue";
+import mapIconCircle from "~/assets/map-icon-circle.svg?data";
+import mapIconDiamond from "~/assets/map-icon-diamond.svg?data";
+import mapIconSquare from "~/assets/map-icon-square.svg?data";
 
 export default {
   computed: {
@@ -57,6 +65,21 @@ export default {
       },
     });
 
+    const mapIconCircleImg = new Image(36, 36);
+    mapIconCircleImg.onload = () =>
+      this.map.addImage("icon-circle", mapIconCircleImg);
+    mapIconCircleImg.src = mapIconCircle;
+
+    const mapIconDiamondImg = new Image(36, 36);
+    mapIconDiamondImg.onload = () =>
+      this.map.addImage("icon-diamond", mapIconDiamondImg);
+    mapIconDiamondImg.src = mapIconDiamond;
+
+    const mapIconSquareImg = new Image(36, 36);
+    mapIconSquareImg.onload = () =>
+      this.map.addImage("icon-square", mapIconSquareImg);
+    mapIconSquareImg.src = mapIconSquare;
+
     this.map.on("load", () => {
       this.map.addSource("locations", {
         type: "geojson",
@@ -70,10 +93,21 @@ export default {
 
       this.map.addLayer({
         id: "locations",
-        type: "circle",
         source: "locations",
-        paint: {
-          "circle-radius": [
+        type: "symbol",
+        layout: {
+          "icon-image": [
+            "match",
+            ["to-string", ["get", "appointments_available_all_doses"]],
+            "true",
+            "icon-circle",
+            "false",
+            "icon-diamond",
+            "icon-square",
+          ],
+          "icon-ignore-placement": true,
+          "icon-allow-overlap": true,
+          "icon-size": [
             "interpolate",
             ["exponential", 1.5],
             ["zoom"],
@@ -82,45 +116,36 @@ export default {
               "match",
               ["to-string", ["get", "appointments_available_all_doses"]],
               "true",
-              4,
+              0.25,
               "false",
-              2,
-              2,
+              0.125,
+              0.125,
             ],
             5,
             [
               "match",
               ["to-string", ["get", "appointments_available_all_doses"]],
               "true",
-              8,
+              0.5,
               "false",
-              5,
-              5,
+              0.3125,
+              0.3125,
             ],
             16,
             [
               "match",
               ["to-string", ["get", "appointments_available_all_doses"]],
               "true",
-              16,
+              1.0,
               "false",
-              10,
-              10,
+              0.625,
+              0.625,
             ],
           ],
-          "circle-stroke-color": "#ffffff",
-          "circle-stroke-width": 1.5,
-          "circle-stroke-opacity": 0.8,
-          "circle-opacity": 0.8,
-          "circle-color": [
-            "match",
-            ["to-string", ["get", "appointments_available_all_doses"]],
-            "true",
-            "#2ca25f",
-            "false",
-            "#e34a33",
-            "#636363",
-          ],
+          "symbol-z-order": "source",
+        },
+        paint: {
+          "icon-opacity": 0.8,
         },
       });
 
@@ -197,28 +222,8 @@ export default {
   margin-top: 5px;
 }
 
-#legend span {
-  height: 14px;
-  width: 14px;
-  vertical-align: middle;
-  margin-top: -2px;
-  background-color: #bbb;
-  border-radius: 50%;
-  display: inline-block;
-  border: 1px solid #fff;
+#legend img {
   opacity: 0.8;
-}
-
-#legend span.available-marker {
-  background-color: #2ca25f;
-}
-
-#legend span.unavailable-marker {
-  background-color: #e34a33;
-}
-
-#legend span.unknown-marker {
-  background-color: #636363;
 }
 
 @media (min-width: 992px) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1712,6 +1712,16 @@
   dependencies:
     http-proxy-middleware "^1.0.6"
 
+"@nuxtjs/svg@^0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/svg/-/svg-0.1.12.tgz#a5b2a66070a36e3c5c5183db9e3d89485ef3eb1c"
+  integrity sha512-QJjArXOcQzDn7gzc/pFr960NTediubeZ5djtqV3BkOnZnANSOvtxFp2LnHF6e4rFq9CTEabPr89WZUwrVDemEQ==
+  dependencies:
+    file-loader "^6.0.0"
+    raw-loader "^4.0.0"
+    url-loader "^4.1.0"
+    vue-svg-loader "^0.16.0"
+
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@nuxtjs/youch/-/youch-4.2.3.tgz#36f8b22df5a0efaa81373109851e1d857aca6bed"
@@ -5483,7 +5493,7 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-loader@^6.2.0:
+file-loader@^6.0.0, file-loader@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
   integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
@@ -10284,6 +10294,14 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
+raw-loader@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
+  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 rc9@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rc9/-/rc9-1.2.0.tgz#ef098181fdde714efc4c426383d6e46c14b1254a"
@@ -11610,7 +11628,14 @@ svg-tags@^1.0.0:
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
 
-svgo@^1.0.0:
+svg-to-vue@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/svg-to-vue/-/svg-to-vue-0.7.0.tgz#ec86deb1742be38319462e36703af1dfa2f9fad9"
+  integrity sha512-Tg2nMmf3BQorYCAjxbtTkYyWPVSeox5AZUFvfy4MoWK/5tuQlnA/h3LAlTjV3sEvOC5FtUNovRSj3p784l4KOA==
+  dependencies:
+    svgo "^1.3.2"
+
+svgo@^1.0.0, svgo@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.3.2.tgz#b6dc511c063346c9e415b81e43401145b96d4167"
   integrity sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==
@@ -12254,7 +12279,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-loader@^4.1.1:
+url-loader@^4.1.0, url-loader@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
   integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==
@@ -12502,6 +12527,14 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.3:
   dependencies:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
+
+vue-svg-loader@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/vue-svg-loader/-/vue-svg-loader-0.16.0.tgz#adccbdc9aca90132bde9c9d96cd49f74efecd345"
+  integrity sha512-2RtFXlTCYWm8YAEO2qAOZ2SuIF2NvLutB5muc3KDYoZq5ZeCHf8ggzSan3ksbbca7CJ/Aw57ZnDF4B7W/AkGtw==
+  dependencies:
+    loader-utils "^1.2.3"
+    svg-to-vue "^0.7.0"
 
 vue-template-compiler@^2.6.12:
   version "2.6.12"


### PR DESCRIPTION
- Use shapes to distinguish the various availability states of locations, instead of just relying on colors.

  Trying to put symbols inside the icons to match our other places (eg, checks and "x"s) seems to be too busy with this many icons on the map, so hopefully some distinctive shapes will help disambiguate things regardless of colors.
- Adjust the colors to also try and provide better distinction for color blindness. The new colors are based on Tol's Bright scheme (https://personal.sron.nl/~pault/), adjusted slightly due to our 80% opacity to still try and match the original colors in Tol's scheme (although given the opacity, we're not totally able to match things).

  I still wanted to try to use something red/green/gray based, which I'm hoping provides better signals as to the meaning, but hopefully these shades in Tol's scheme will be slightly better for everyone, while still having the shape distinction as further backup.

Sorry this has taken so long, but this should fix #57, #67, and #92.