### PR TITLE
Fix #106: make legend a little taller so it doesn't scroll in chrome

### DIFF
--- a/website/components/LocationMap.vue
+++ b/website/components/LocationMap.vue
@@ -215,7 +215,7 @@ export default {
   padding: 8px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
   line-height: 16px;
-  height: 64px;
+  height: 67px;
   width: 210px;
   font-size: 0.75rem;
   top: 0px;


### PR DESCRIPTION
Fixes #106 

After the change: 
<img width="898" alt="a screenshot of the vaccine spotter for alabama, showing the legend does not scroll" src="https://user-images.githubusercontent.com/4480480/112881125-ecf37280-9090-11eb-8bb0-74df685795f9.png">

Before this change: 
<img width="910" alt="a screenshot of the vaccine spotter for alabama, showing the legend has a scroll" src="https://user-images.githubusercontent.com/4480480/112881235-0ac0d780-9091-11eb-90be-a31f85e97791.png">


`Overflow:hidden` doesn't work here for accessibility reasons - if the user has a larger minimum font size set in their browser, the text will just be cut off if `overflow: hidden` is set. Right now, if the text is larger than expected due to the user's accessibility settings on their browser, the text will scroll but still be usable.