### PR TITLE
Bugfix - Quick map fix for null entries

### DIFF
--- a/website/components/LocationMap.vue
+++ b/website/components/LocationMap.vue
@@ -81,9 +81,12 @@ export default {
     mapIconSquareImg.src = mapIconSquare;
 
     this.map.on("load", () => {
+      const stateData = this.$store.state.usStates.usState
+      stateData.features.splice(0, stateData.features.length, ...stateData.features.filter(feature => feature.geometry.coordinates[0] != null));
+      stateData.metadata.store_count = stateData.features.length;
       this.map.addSource("locations", {
         type: "geojson",
-        data: this.$store.state.usStates.usState,
+        data: stateData,
       });
 
       this.zipMarker = new Marker();


### PR DESCRIPTION
This is to address #103. Not the best code in the world but concise. Removes null entries to prevent map from putting locations on "null island"

Before: 
![image](https://user-images.githubusercontent.com/10392896/112898276-9e54d100-90ae-11eb-9825-5cb460163543.png)
After:
![image](https://user-images.githubusercontent.com/10392896/112898366-bf1d2680-90ae-11eb-9f4b-a311e0f28bec.png)

I know this isn't the best JS in the world, so do let me know if mapbox or CARTO provides a better way of doing this (I couldn't find any)

Happy and excited to help!