### PR TITLE
require node 14+ in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
     "lint": "yarn lint:js"
   },
+  "engines" : { "node" : ">=14" },
   "dependencies": {
     "@cliqz/adblocker-playwright": "^1.20.3",
     "@extra/humanize": "^4.2.2-next.616",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
     "lint": "yarn lint:js"
   },
-  "engines" : { "node" : ">=14" },
+  "engines": {
+    "node": ">=14"
+  },
   "dependencies": {
     "@cliqz/adblocker-playwright": "^1.20.3",
     "@extra/humanize": "^4.2.2-next.616",


### PR DESCRIPTION
I noticed that yarn was requiring node 10+ but the README specifies 14+ - this will enforce the right node version for local dev:

<img width="865" alt="image" src="https://user-images.githubusercontent.com/2084598/113312980-6e851380-92d0-11eb-9f0e-220a41042e2a.png">
