### PR TITLE
Changes zipcode to only accept numbers

### DIFF
--- a/website/components/LocationFiltersForm.vue
+++ b/website/components/LocationFiltersForm.vue
@@ -9,7 +9,7 @@
           <input
             id="zip"
             v-model="queryZip"
-            type="text"
+            type="number"
             name="zip"
             class="form-control form-control-lg"
             placeholder="Enter a 5 digit ZIP code"


### PR DESCRIPTION
This change fixes #123. By changing the input type from text to number, mobile will default to showing the number pad. Desktop/laptop users will still type into the box, but letters will be rejected.