### PR TITLE
Fix invalid db migration

### DIFF
--- a/migrations/20210408224048_convert_materialized_views.js
+++ b/migrations/20210408224048_convert_materialized_views.js
@@ -72,18 +72,6 @@ exports.up = async function (knex) {
   );
 
   await knex.raw(
-    "CREATE TABLE country_grid_25km_real (LIKE country_grid_25km INCLUDING ALL)"
-  );
-  await knex.raw(
-    "INSERT INTO country_grid_25km_real SELECT * FROM country_grid_25km"
-  );
-  await knex.raw("DROP MATERIALIZED VIEW country_grid_25km");
-  await knex.raw(
-    "ALTER TABLE country_grid_25km_real RENAME TO country_grid_25km"
-  );
-  await knex.raw("ALTER TABLE country_grid_25km ADD PRIMARY KEY (id)");
-
-  await knex.raw(
     "CREATE TABLE country_grid_55km_real (LIKE country_grid_55km INCLUDING ALL)"
   );
   await knex.raw(


### PR DESCRIPTION
`country_grid_25km` appears to be a typo: it was never created prior to the migration in `20210408224048_convert_materialized_views.js` and appears not to be currently used.

This change prevents the bootstrap_db from failing with

migration failed with error: CREATE TABLE country_grid_25km_real (LIKE country_grid_25km INCLUDING ALL) - relation "country_grid_25km" does not exist

For convenience, the `db/structure.sql` is also updated.
