### PR TITLE
Handle relative path properly in bootstrap_db bin/import-states

### DIFF
--- a/src/handlers/importStates.js
+++ b/src/handlers/importStates.js
@@ -6,10 +6,14 @@ const topojson = require("topojson-client");
 const { State } = require("../models/State");
 
 const states500kTopojson = JSON.parse(
-  fs.readFileSync("../../tmp/cb_2018_us_state_500k.topojson")
+  fs.readFileSync(
+    path.resolve(__dirname, "../../tmp/cb_2018_us_state_500k.topojson")
+  )
 );
 const states5mTopojson = JSON.parse(
-  fs.readFileSync("../../tmp/cb_2018_us_state_5m.topojson")
+  fs.readFileSync(
+    path.resolve(__dirname, "../../tmp/cb_2018_us_state_5m.topojson")
+  )
 );
 
 const statesGeojson = topojson.feature(


### PR DESCRIPTION
When the bootstrap_db runs /app/bin/import-states, its cwd is /app, not /app/src/handlers, creating an error

```
bootstrap_db_1  | Error: ENOENT: no such file or directory, open '../../tmp/cb_2018_us_state_500k.topojson'
bootstrap_db_1  |     at Object.openSync (fs.js:476:3)
bootstrap_db_1  |     at Object.readFileSync (fs.js:377:35)
bootstrap_db_1  |     at Object.<anonymous> (/app/src/handlers/importStates.js:9:6)
bootstrap_db_1  |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
bootstrap_db_1  |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
bootstrap_db_1  |     at Module.load (internal/modules/cjs/loader.js:928:32)
bootstrap_db_1  |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
bootstrap_db_1  |     at Module.require (internal/modules/cjs/loader.js:952:19)
bootstrap_db_1  |     at require (internal/modules/cjs/helpers.js:88:18)
bootstrap_db_1  |     at Object.<anonymous> (/app/bin/import-states:3:26) {
bootstrap_db_1  |   errno: -2,
bootstrap_db_1  |   syscall: 'open',
bootstrap_db_1  |   code: 'ENOENT',
bootstrap_db_1  |   path: '../../tmp/cb_2018_us_state_500k.topojson'
bootstrap_db_1  | }
```