### PR TITLE
Added filtering based on pharmacy chain #54

### DIFF
--- a/website/components/LocationFiltersForm.vue
+++ b/website/components/LocationFiltersForm.vue
@@ -72,11 +72,12 @@
         </div>
         <div class="col-sm">
           <label for="provider" class="form-label form-label-sm"
-            >Pharmacy</label
+            >Pharmacy (multi-select)</label
           >
           <select
             id="provider"
             v-model="queryProvider"
+            multiple
             name="provider"
             class="form-select form-select-sm mb-3"
             @change="submitForm"
@@ -163,10 +164,21 @@ export default {
 
     queryProvider: {
       get() {
-        return this.$route.query.provider || "";
+        const providers = this.$route.query.provider;
+        return providers || [""];
       },
       set(value) {
-        this.pendingQueryParams.provider = value;
+        if (value.includes("")) {
+          const allValues = [];
+          this.$store.state.usStates.usState.metadata.provider_brands.forEach(
+            (providerBrand) => {
+              allValues.push(providerBrand.id);
+            }
+          );
+          this.pendingQueryParams.provider = allValues;
+        } else {
+          this.pendingQueryParams.provider = value;
+        }
       },
     },
 

--- a/website/store/usStates.js
+++ b/website/store/usStates.js
@@ -102,7 +102,9 @@ export const getters = {
 
       if (
         queryProvider &&
-        location.properties.provider_brand_id !== parseInt(queryProvider, 10)
+        !queryProvider.includes(
+          location.properties.provider_brand_id.toString()
+        )
       ) {
         include = false;
       }


### PR DESCRIPTION
Previously, a user has been able to select one pharmacy from a dropdown menu to filter results by. Now, users will see a multi-select element that allows them to select multiple pharmacy chains to view. This is done by holding down the Ctrl (Windows) or Command (Mac) button while selecting different options. This addresses [#54](https://github.com/GUI/covid-vaccine-spotter/issues/54).