### PR TITLE
Made provider address / location clickable #138

### DIFF
--- a/website/components/Store.vue
+++ b/website/components/Store.vue
@@ -4,7 +4,10 @@
     <div class="card-header">
       <div class="row">
         <h5 class="col-sm mb-0">
-          {{ title }}
+          {{ title }} -
+          <a :href="`${fullAddressLink}`" target="_blank">
+            {{ fullAddress }}
+          </a>
         </h5>
         <div v-if="store.distance" class="col-sm-auto">
           {{ store.distance }} miles
@@ -144,7 +147,6 @@ export default {
       ) {
         title += ` - ${this.store.properties.name}`;
       }
-      title += ` - ${this.fullAddress}`;
 
       return title;
     },
@@ -159,6 +161,12 @@ export default {
       ]
         .filter((value) => !!value)
         .join(", ");
+    },
+
+    fullAddressLink() {
+      let link = "https://www.google.com/maps/place/";
+      link += `${this.fullAddress}`.replace(/ /g, "+");
+      return link;
     },
   },
 


### PR DESCRIPTION
In the display list of providers with vaccination appointments, the name of the provider is presented along with its address / location. I made the address clickable, as requested in #138, so users can click on the address and see the location pulled up in Google Maps (in a new tab). 