### PR TITLE
Made instructions collapsable #145

### DIFF
--- a/website/pages/_state.vue
+++ b/website/pages/_state.vue
@@ -10,7 +10,16 @@
           {{ description }}
         </p>
 
-        <div class="row mb-2">
+        <button
+          id="instructionsVisibilityButton"
+          class="btn btn-primary"
+          type="button"
+          @click="hideShowInstructions"
+        >
+          Hide Instructions
+        </button>
+
+        <div id="instructions" class="row mb-2">
           <div class="col-md-6 pb-3">
             <div class="card card-body h-100 bg-primary text-white shadow-sm">
               <h2 class="display-6 text-center mb-4">
@@ -205,6 +214,20 @@ export default {
       return this.$store.getters["usStates/getFilterError"];
     },
   },
+  methods: {
+    hideShowInstructions() {
+      const x = document.getElementById("instructions");
+      if (x.style.display === "none") {
+        x.style.display = "flex";
+        document.getElementById("instructionsVisibilityButton").innerHTML =
+          "Hide Instructions";
+      } else {
+        x.style.display = "none";
+        document.getElementById("instructionsVisibilityButton").innerHTML =
+          "Show Instructions";
+      }
+    },
+  },
 };
 </script>
 
@@ -231,5 +254,9 @@ export default {
 
 .results-container .location-result:last-child {
   margin-bottom: 0px !important;
+}
+
+#instructionsVisibilityButton {
+  margin-bottom: 1rem;
 }
 </style>


### PR DESCRIPTION
On a specific state's page, the instructions take up a large portion of the screen space, requiring a user to scroll down to find the main functionality and results. As requested in #145, I made the instructions collapsable in order to make the rest of the page more accessible. There is now a "Show / Hide Instructions" button that when clicked on will either hide the instructions or show the instructions, depending on the current state of the page. 