### PR TITLE
Add generic prepmod support

### DIFF
--- a/bin/maimmunizations-refresh-appointments
+++ b/bin/maimmunizations-refresh-appointments
@@ -3,4 +3,4 @@
 const { refreshStores } = require("../src/providers/PrepMod/Appointments");
 const runTask = require("../src/runTask");
 
-runTask(refreshStores('comassvax', 'https://www.comassvax.org'), 15000);
+runTask(refreshStores('maimmunizations', 'https://clinics.maimmunizations.org'), 15000);

--- a/src/providers/PrepMod/Appointments.js
+++ b/src/providers/PrepMod/Appointments.js
@@ -75,12 +75,13 @@ class Appointments {
   static async fetchSearchPage(url, pageNum) {
     logger.info(`Fetching page ${pageNum} of search results`);
     await sleep(_.random(250, 750));
+    const searchParams = new URLSearchParams([
+      ["q[services_name_in][]", "covid"],
+      ["q[services_name_in][]", "Vaccination"],
+      ["page", pageNum]
+    ]);
     return got(url, {
-      searchParams: {
-        "q[services_name_in][]": "covid",
-        "q[services_name_in][]": "Vaccination",
-        page: pageNum,
-      },
+      searchParams,
       headers: {
         "User-Agent": "VaccineSpotter.org",
       },

--- a/src/providers/PrepMod/Appointments.js
+++ b/src/providers/PrepMod/Appointments.js
@@ -13,65 +13,72 @@ const { Provider } = require("../../models/Provider");
 const { ProviderBrand } = require("../../models/ProviderBrand");
 
 class Appointments {
-  static async refreshStores() {
-    logger.notice("Begin refreshing appointments for all stores...");
+  static refreshStores(provider_id, url) {
+    return async function () {
+      logger.notice(`Begin refreshing appointments for all stores in ${provider_id}...`);
 
-    await Provider.query()
-      .insert({
-        id: "comassvax",
-      })
-      .onConflict(["id"])
-      .merge();
+      const search_url = `${url}/clinic/search`;
 
-    await ProviderBrand.query()
-      .insert({
-        provider_id: "comassvax",
-        key: "comassvax",
-        name: "PrepMod",
-        url: "https://www.comassvax.org/clinic/search",
-      })
-      .onConflict(["provider_id", "key"])
-      .merge();
-    Appointments.providerBrand = await ProviderBrand.query().findOne({
-      provider_id: "comassvax",
-      key: "comassvax",
-    });
-
-    Appointments.patches = {};
-
-    let pageNum = 1;
-    let hasNextPage = true;
-    while (hasNextPage) {
-      const lastFetched = DateTime.utc().toISO();
-      const pageResp = await Appointments.fetchSearchPage(pageNum);
-      hasNextPage = await Appointments.processSearchPage(
-        pageNum,
-        pageResp,
-        lastFetched
-      );
-
-      pageNum += 1;
-    }
-
-    for (const patch of Object.values(Appointments.patches)) {
-      patch.appointments = _.orderBy(patch.appointments, ["time", "type"]);
-      setComputedStoreValues(patch);
-
-      await Store.query()
-        .insert(patch)
-        .onConflict(["provider_id", "provider_location_id"])
+      await Provider.query()
+        .insert({
+          id: provider_id,
+        })
+        .onConflict(["id"])
         .merge();
-    }
 
-    logger.notice("Finished refreshing appointments for all stores.");
+      await ProviderBrand.query()
+        .insert({
+          provider_id: provider_id,
+          key: provider_id,
+          name: "PrepMod",
+          url: search_url,
+        })
+        .onConflict(["provider_id", "key"])
+        .merge();
+      Appointments.providerBrand = await ProviderBrand.query().findOne({
+        provider_id: provider_id,
+        key: provider_id,
+      });
+
+      Appointments.patches = {};
+
+      let pageNum = 1;
+      let hasNextPage = true;
+      while (hasNextPage) {
+        const lastFetched = DateTime.utc().toISO();
+        const pageResp = await Appointments.fetchSearchPage(search_url, pageNum);
+        hasNextPage = await Appointments.processSearchPage(
+          provider_id,
+          url,
+          pageNum,
+          pageResp,
+          lastFetched
+        );
+
+        pageNum += 1;
+      }
+
+      for (const patch of Object.values(Appointments.patches)) {
+        patch.appointments = _.orderBy(patch.appointments, ["time", "type"]);
+        setComputedStoreValues(patch);
+
+        await Store.query()
+          .insert(patch)
+          .onConflict(["provider_id", "provider_location_id"])
+          .merge();
+      }
+
+      logger.notice("Finished refreshing appointments for all stores.");
+    }
   }
 
-  static async fetchSearchPage(pageNum) {
+  static async fetchSearchPage(url, pageNum) {
     logger.info(`Fetching page ${pageNum} of search results`);
     await sleep(_.random(250, 750));
-    return got("https://www.comassvax.org/clinic/search", {
+    return got(url, {
       searchParams: {
         "q[services_name_in][]": "covid",
+        "q[services_name_in][]": "Vaccination",
         page: pageNum,
       },
       headers: {
@@ -82,7 +89,7 @@ class Appointments {
     });
   }
 
-  static async processSearchPage(pageNum, resp, lastFetched) {
+  static async processSearchPage(provider_id, url, pageNum, resp, lastFetched) {
     const $page = cheerio.load(resp.body);
     const searchResults = $page(".md\\:flex-shrink:has(.text-xl)");
     for (const searchResult of searchResults) {
@@ -107,7 +114,7 @@ class Appointments {
       let patch = Appointments.patches[providerLocationId];
       if (!patch) {
         patch = {
-          provider_id: "comassvax",
+          provider_id: provider_id,
           provider_location_id: providerLocationId,
           provider_brand_id: Appointments.providerBrand.id,
           active: true,
@@ -167,7 +174,7 @@ class Appointments {
         .find("[href*='/client/registration']")
         .attr("href");
       if (signUpLink) {
-        const signUpResp = await Appointments.fetchSignUpPage(signUpLink);
+        const signUpResp = await Appointments.fetchSignUpPage(url, signUpLink);
         const $signUpPage = cheerio.load(signUpResp.body);
 
         const timeRadios = $signUpPage(
@@ -207,10 +214,10 @@ class Appointments {
     return false;
   }
 
-  static async fetchSignUpPage(link) {
+  static async fetchSignUpPage(url, link) {
     logger.info(`Fetching sign up page ${link} for appointment slots`);
     await sleep(_.random(250, 750));
-    return got(`https://www.comassvax.org${link}`, {
+    return got(`${url}${link}`, {
       headers: {
         "User-Agent": "VaccineSpotter.org",
       },

--- a/website/components/LocationMapPopup.vue
+++ b/website/components/LocationMapPopup.vue
@@ -100,6 +100,7 @@ export default {
       if (
         this.store.properties.provider_brand === "centura_driveup_event" ||
         this.store.properties.provider_brand === "comassvax" ||
+        this.store.properties.provider_brand === "maimmunizations" ||
         this.store.properties.provider_brand === "costco" ||
         this.store.properties.provider_brand === "health_mart"
       ) {

--- a/website/components/Store.vue
+++ b/website/components/Store.vue
@@ -139,6 +139,7 @@ export default {
       if (
         this.store.properties.provider_brand === "centura_driveup_event" ||
         this.store.properties.provider_brand === "comassvax" ||
+        this.store.properties.provider_brand === "maimmunizations" ||
         this.store.properties.provider_brand === "costco" ||
         this.store.properties.provider_brand === "health_mart"
       ) {


### PR DESCRIPTION
Hello! I noticed that many states use the same PrepMod system under different URLs, and thought it would be cool to make the code a bit more generic and add the Massachusetts system to vaccine-spotter. The only real change was to allow the `refreshStores` function to take some arguments to define the provider and URL to scrape, and then return a function that `runTask` can call. I also had to change the handling of `searchParams` in `fetchSearchPage` to allow for searching both "covid" and "Vaccination" but honestly I don't think the PrepMod sites ever actually return results for the other selectors (like Testing/Screening) so you could probably drop the `services_name_in` param entirely. I tested this out locally and both `maimmunizations` and `comassvax` seem to work, although I was only able to get so far as verifying that they inserted rows into the database and not to the point where I ran the UI to see them.

I think this code could also help solve #94 and a few other states like [Rhode Island](https://www.vaccinateri.org/clinic/search).