### PR TITLE
Added the ability to search by the user's current location & Custom message for the state of Florida

### DIFF
--- a/website/components/LocationFiltersForm.vue
+++ b/website/components/LocationFiltersForm.vue
@@ -1,3 +1,4 @@
+const lib = require("./MinHeap");
 <template>
   <form class="row g-2 location-filters" @submit.prevent="submitForm">
     <div class="col-sm">
@@ -113,9 +114,14 @@
     <div class="col-auto">
       <button type="submit" class="btn btn-primary btn-lg">Search</button>
     </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary btn-lg" @click="Location">Find Locations near me</button>
+    </div>
+        <div class="col-auto">
+      <button type="submit" class="btn btn-primary btn-lg" @click="clearLoc">Clear Location</button>
+    </div>
   </form>
 </template>
-
 <script>
 export default {
   data() {
@@ -123,8 +129,15 @@ export default {
       pendingQueryParams: {},
     };
   },
-
   computed: {
+    queryLoc:{
+      get(){
+        return this.$route.query.loc || "";
+      },
+      set(_lat, _lon){
+        this.pendingQueryParams.loc = [_lon,_lat];
+      }
+    },
     queryZip: {
       get() {
         return this.$route.query.zip || "";
@@ -184,6 +197,10 @@ export default {
     submitForm() {
       const newQuery = { ...this.$route.query, ...this.pendingQueryParams };
 
+      if (newQuery.loc === ""){
+        delete newQuery.loc;
+      }
+
       if (newQuery.zip === "") {
         delete newQuery.zip;
       }
@@ -214,6 +231,23 @@ export default {
       });
       this.pendingQueryParams = {};
     },
+  Location(){
+    navigator.geolocation.getCurrentPosition(position => {
+      this.pendingQueryParams.loc = [position.coords.longitude,position.coords.latitude];
+      this.pendingQueryParams.zip = "";
+      this.submitForm();
+    },
+    error => {
+      console.log(error);
+      alert("Location is not enabled. Please enable location services.");
+    },
+    );
+  },
+  clearLoc(){
+    this.pendingQueryParams.loc = "";
+    this.pendingQueryParams.zip = ""
+    this.submitForm();
+  }
   },
 };
 </script>

--- a/website/components/LocationMap.vue
+++ b/website/components/LocationMap.vue
@@ -42,6 +42,10 @@ export default {
       return this.$store.state.usStates.usState;
     },
 
+    locCoords(){
+      return this.$store.getters["usStates/getMapLocCoords"];
+    },
+
     zipCoords() {
       return this.$store.getters["usStates/getMapZipCoords"];
     },
@@ -63,10 +67,31 @@ export default {
       this.setMapBounds();
     },
 
+    locCoords() {
+      if (this.locMarker) {
+        if (this.locCoords) {
+      
+          if(this.zipMarker){
+            this.zipMarker.remove();
+          }
+            this.locMarker.setLngLat(this.locCoords).addTo(this.map);
+
+        } else {
+          this.locMarker.remove();
+        }
+      }
+    },
+
     zipCoords() {
       if (this.zipMarker) {
         if (this.zipCoords) {
+
+          if(this.locMarker){
+            this.locMarker.remove();
+          }
+
           this.zipMarker.setLngLat(this.zipCoords).addTo(this.map);
+          
         } else {
           this.zipMarker.remove();
         }
@@ -108,6 +133,8 @@ export default {
         },
       });
       this.mapSource = this.map.getSource("locations");
+
+      this.locMarker = new Marker();
 
       this.zipMarker = new Marker();
 

--- a/website/pages/_state.vue
+++ b/website/pages/_state.vue
@@ -32,12 +32,38 @@
                   You may be able to signup for vaccines with a health care
                   provider in your area (Kaiser, SCL Health, your county, etc.),
                   in which case you will be contacted when it's your turn and
-                  you may not need this tool.
+                  you may not need this tool. We recommend viewing other options 
+                  in the case that you are not able to schedule a vaccine through this tool.
                 </p>
                 <a
                   href="https://covid19.colorado.gov/for-coloradans/vaccine/where-can-i-get-vaccinated"
                   class="btn btn-light fw-bold fs-5 text-primary"
                   >Visit Colorado.gov
+                  <font-awesome-icon icon="arrow-alt-circle-right"
+                /></a>
+              </template>
+              <template v-else-if="usStateCode == 'FL'">
+                <p class="lead">
+                  Visit
+                  <a
+                    href="https://floridahealthcovid19.gov/vaccines/vaccine-locator/"
+                    class="text-white"
+                    ><strong class="fw-bold">FloridaHealth.gov</strong></a
+                  >
+                  for detailed information about your county's vaccine options
+                  and review whether or not you are eligible yet.
+                </p>
+                <p class="lead">
+                  You may be able to signup for vaccines with a health care
+                  provider or there may be other options in your area, 
+                  such as through a public University (not supported). 
+                  We recommend viewing other options in the case that you are not able
+                  to schedule a vaccine through this tool.
+                </p>
+                <a
+                  href="https://floridahealthcovid19.gov/vaccines/vaccine-locator/"
+                  class="btn btn-light fw-bold fs-5 text-primary"
+                  >Visit FloridaHealth.gov
                   <font-awesome-icon icon="arrow-alt-circle-right"
                 /></a>
               </template>
@@ -50,7 +76,8 @@
                 <p class="lead">
                   You may be able to signup for vaccines with a health care
                   provider or there may be other options in your area, in which
-                  case you may not need this tool.
+                  case you may not need this tool. We recommend viewing other options 
+                  in the case that you are not able to schedule a vaccine through this tool.
                 </p>
               </template>
             </div>

--- a/website/pages/index.vue
+++ b/website/pages/index.vue
@@ -53,7 +53,7 @@ export default {
     return {
       title: "COVID-19 Vaccine Spotter",
       description:
-        "A tool to help you track down COVID-19 vaccine appointment openings at your state's pharmacies. Updated every minute.",
+        "A tool to help you track down COVID-19 vaccine appointment openings at your state's pharmacies. Updated every minute!",
       states: [],
     };
   },


### PR DESCRIPTION
Using the same mechanisms already implemented through the ZIP code search, I added the ability to search for the nearest vaccine locations to the user using the current GPS coordinates of the user (using navigator.geolocation.getCurrentPosition() function). Also, I added the ability to clear the location search which removes both the searched ZIP code & current location. Additionally added a custom message in the Step 1 box when the state of Florida is selected (similar to the custom message when the state of Colorado is selected) ... more custom messages to come.

Current FL message:
![current](https://user-images.githubusercontent.com/56684133/117163003-3d957400-ad91-11eb-8c2a-bdb65a08f829.PNG)

New FL message:
![new](https://user-images.githubusercontent.com/56684133/117163063-4be39000-ad91-11eb-8b23-2e7a70b9ae0e.PNG)


