### PR TITLE
Fix bad dates & missing vaccine types for Publix

### DIFF
--- a/src/providers/Publix/Appointments.js
+++ b/src/providers/Publix/Appointments.js
@@ -81,7 +81,7 @@ class Appointments {
             type: stateMetadata.vaccineType,
             time: DateTime.fromFormat(
               `${appointment.DisplayDate} ${appointment.DisplayTime}`,
-              "L/dd/yyyy h:mm a",
+              "L/d/yyyy h:mm a",
               {
                 zone: store.time_zone,
               }
@@ -152,13 +152,14 @@ class Appointments {
     }
 
     const vaccineTypes = [];
-    if (/appointments for .*(Johnson|Janssen)/i.test(bodyText)) {
+    const vaccineButtons = $body(".vaccineButtons").text();
+    if (/Johnson|Janssen/i.test(bodyText)) {
       vaccineTypes.push("Johnson & Johnson");
     }
-    if (/appointments for .*Moderna/i.test(bodyText)) {
+    if (/Moderna/i.test(bodyText)) {
       vaccineTypes.push("Moderna");
     }
-    if (/appointments for .*Pfizer/i.test(bodyText)) {
+    if (/Pfizer/i.test(bodyText)) {
       vaccineTypes.push("Pfizer");
     }
 


### PR DESCRIPTION
**This code is untested!** I don't have a good setup for running this, but these changes match what I'm seeing from the Publix website. Please run and test before merging.

I’m seeing a lot of Publix entries with unknown vaccine type and bad appointment entries like:

```js
{
  "appointments": [
    {
      "time": null,
      "type": "",
      "vaccine_types": [],
      "appointment_types": []
    },
    {
      "time": null,
      "type": "",
      "vaccine_types": [],
      "appointment_types": []
    }
  ]
}
```

This *should* fix the issues, as far as I can tell from looking at Publix's site.